### PR TITLE
Gitignore the `build.js` file emitted by `tsc`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+build/

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint . --ext .ts",
-    "package": "tsc && ncc build index.js -o dist --source-map --license licenses.txt"
+    "package": "tsc && ncc build build/index.js -o dist --source-map --license licenses.txt"
   },
   "keywords": [],
   "author": "Ably",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "outDir": "build"
   }
 }


### PR DESCRIPTION
Emit it to a `build/` directory which we then ignore (the directory isn't necessary; just nice to not have build artifact files at the top level of the repo).